### PR TITLE
Update pretrain_IJEPA.py

### DIFF
--- a/pretrain_IJEPA.py
+++ b/pretrain_IJEPA.py
@@ -112,6 +112,7 @@ class IJEPA(pl.LightningModule):
         self.embed_dim = embed_dim
         self.patch_size = patch_size
         self.num_tokens = (img_size // patch_size) ** 2
+        self.m_start_end = m_start_end
 
         #define loss
         self.criterion = nn.MSELoss()


### PR DESCRIPTION
Add the m_start_end parms as an attribute for the class IJEPA, because it's producing an error while training:
` AttributeError: 'IJEPA' object has no attribute 'm_start_end`