### PR TITLE
Update pretrain_IJEPA.py by fixing a UserWarning in add_

### DIFF
--- a/pretrain_IJEPA.py
+++ b/pretrain_IJEPA.py
@@ -125,7 +125,7 @@ class IJEPA(pl.LightningModule):
         teacher_model = self.model.teacher_encoder.eval()
         with torch.no_grad():
             for student_param, teacher_param in zip(student_model.parameters(), teacher_model.parameters()):
-                teacher_param.data.mul_(m).add_(1 - m, student_param.data)
+                teacher_param.data.mul_(other=m).add_(other=student_param.data, alpha=1 - m)
 
 
     def training_step(self, batch, batch_idx):


### PR DESCRIPTION
Fixing the warning: "UserWarning: This overload of add_ is deprecated: 
```
add_(Number alpha, Tensor other)
Consider using one of the following signatures instead: add_(Tensor other, *, Number alpha) (Triggered internally at /opt/conda/conda-bld/pytorch_1595661244635/work/torch/csrc/utils/python_arg_parser.cpp:797.)
```